### PR TITLE
Add activationEvents for lazy loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "Other"
   ],
   "main": "./src/extension.js",
+  "activationEvents": [
+    "onCommand:my-extension.helloWorld"
+  ],
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION
## Summary
- Add explicit `activationEvents` to `package.json` so the extension only loads when its registered commands are invoked.
- Avoids eager activation on every VS Code window start — measurable startup perf win for users with many extensions.

## Test plan
- [ ] CI passes (lint, package validation)
- [ ] `vsce package` builds a valid `.vsix`
- [ ] F5 in host window still activates commands on first invocation