### PR TITLE
test: audit and upgrade extension tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     ]
   },
   "scripts": {
-    "lint": "eslint src/",
-    "test": "jest --verbose --passWithNoTests",
+    "lint": "eslint src/ tests/",
+    "test": "jest --verbose",
+    "vscode:prepublish": "npm run lint && npm test",
     "package": "vsce package --no-dependencies",
     "version:patch": "node scripts/bump-version.js patch",
     "version:minor": "node scripts/bump-version.js minor",

--- a/tests/__mocks__/vscode.js
+++ b/tests/__mocks__/vscode.js
@@ -1,15 +1,51 @@
+/**
+ * Minimal vscode API mock for unit tests.
+ *
+ * Uses jest.fn() so tests can assert on call arguments and invoke registered
+ * command handlers. Keeps surface area narrow — extend only when a test needs it.
+ */
+const registeredCommands = new Map();
+
+const commands = {
+  registerCommand: jest.fn((id, handler) => {
+    registeredCommands.set(id, handler);
+    return { dispose: jest.fn(() => registeredCommands.delete(id)) };
+  }),
+  executeCommand: jest.fn((id, ...args) => {
+    const handler = registeredCommands.get(id);
+    if (!handler) {
+      return Promise.reject(new Error(`Command not registered: ${id}`));
+    }
+    return Promise.resolve(handler(...args));
+  }),
+  getCommands: jest.fn(() => Promise.resolve([...registeredCommands.keys()])),
+};
+
+const window = {
+  showInformationMessage: jest.fn(),
+  showErrorMessage: jest.fn(),
+  showWarningMessage: jest.fn(),
+};
+
+const workspace = {
+  getConfiguration: jest.fn(() => ({ get: jest.fn() })),
+};
+
 module.exports = {
-  commands: {
-    registerCommand: () => ({ dispose: () => {} }),
-  },
-  window: {
-    showInformationMessage: () => {},
-    showErrorMessage: () => {},
-    showWarningMessage: () => {},
-  },
-  workspace: {
-    getConfiguration: () => ({ get: () => {} }),
-  },
+  commands,
+  window,
+  workspace,
   Uri: { file: (f) => f, parse: (s) => s },
   ExtensionContext: {},
+  // Exposed for test setup/teardown only — not part of the real vscode API.
+  __reset: () => {
+    registeredCommands.clear();
+    commands.registerCommand.mockClear();
+    commands.executeCommand.mockClear();
+    commands.getCommands.mockClear();
+    window.showInformationMessage.mockClear();
+    window.showErrorMessage.mockClear();
+    window.showWarningMessage.mockClear();
+    workspace.getConfiguration.mockClear();
+  },
 };

--- a/tests/extension.test.js
+++ b/tests/extension.test.js
@@ -1,18 +1,106 @@
+const vscode = require('vscode');
 const { activate, deactivate } = require('../src/extension');
+const { registerHelloWorld } = require('../src/commands/helloWorld');
+const pkg = require('../package.json');
 
-describe('Extension', () => {
-  test('exports activate function', () => {
-    expect(typeof activate).toBe('function');
+/**
+ * Builds a fresh ExtensionContext-like object for each test.
+ * `subscriptions` mimics the disposable array VS Code provides to activate().
+ */
+function createContext() {
+  return { subscriptions: [] };
+}
+
+beforeEach(() => {
+  vscode.__reset();
+});
+
+describe('registerHelloWorld', () => {
+  test('registers the command id declared in package.json', () => {
+    const context = createContext();
+    const declared = pkg.contributes.commands[0].command;
+
+    registerHelloWorld(context);
+
+    expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(1);
+    expect(vscode.commands.registerCommand).toHaveBeenCalledWith(
+      declared,
+      expect.any(Function)
+    );
   });
 
-  test('exports deactivate function', () => {
-    expect(typeof deactivate).toBe('function');
+  test('pushes the disposable onto context.subscriptions for cleanup', () => {
+    const context = createContext();
+
+    registerHelloWorld(context);
+
+    expect(context.subscriptions).toHaveLength(1);
+    expect(typeof context.subscriptions[0].dispose).toBe('function');
+  });
+
+  test('executing the command shows the hello world message', async () => {
+    const context = createContext();
+    registerHelloWorld(context);
+
+    await vscode.commands.executeCommand('my-extension.helloWorld');
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledTimes(1);
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      'Hello World from My Extension!'
+    );
   });
 });
 
-describe('Commands', () => {
-  test('helloWorld module exports registerHelloWorld', () => {
-    const { registerHelloWorld } = require('../src/commands/helloWorld');
-    expect(typeof registerHelloWorld).toBe('function');
+describe('activate', () => {
+  test('registers the helloWorld command on activation', async () => {
+    const context = createContext();
+
+    activate(context);
+
+    const registered = await vscode.commands.getCommands();
+    expect(registered).toContain('my-extension.helloWorld');
+    expect(context.subscriptions).toHaveLength(1);
+  });
+
+  test('surfaces errors via showErrorMessage instead of throwing', () => {
+    const context = createContext();
+    // Force registerCommand to fail — mimics a broken VS Code host.
+    vscode.commands.registerCommand.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    // activate() intentionally logs via console.error; silence it for clean output.
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      expect(() => activate(context)).not.toThrow();
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(1);
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining('boom')
+      );
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});
+
+describe('deactivate', () => {
+  test('is a no-op that returns undefined', () => {
+    expect(deactivate()).toBeUndefined();
+  });
+});
+
+describe('package.json contract', () => {
+  test('every contributed command is backed by an activationEvent or is auto-activated', () => {
+    // VS Code 1.74+ auto-activates contributed commands, but we still declare
+    // explicit onCommand: entries for clarity. This guards against drift.
+    const contributed = pkg.contributes.commands.map((c) => c.command);
+    expect(contributed).toContain('my-extension.helloWorld');
+    // If activationEvents are declared, ensure each contributed command has one.
+    if (Array.isArray(pkg.activationEvents) && pkg.activationEvents.length > 0) {
+      for (const cmd of contributed) {
+        expect(pkg.activationEvents).toContain(`onCommand:${cmd}`);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

Audited existing tests, confirmed they were thin (typeof checks), and upgraded to behavior-driven unit tests.

### Audit findings
All 3 existing tests were thin — only checked `typeof x === 'function'`:
- `exports activate function` — typeof only
- `exports deactivate function` — typeof only
- `helloWorld module exports registerHelloWorld` — typeof only

**Mutation check**: replacing `registerHelloWorld` with `throw new Error(...)` kept every test green. `activate()` catches errors internally, so even catastrophic failure went undetected.

### Changes
- Upgraded `tests/__mocks__/vscode.js` to use `jest.fn()` so call sites are assertable, plus an in-memory command registry so registered handlers can actually be invoked via `executeCommand`.
- Rewrote `tests/extension.test.js` with 7 behavior tests:
  - `registerHelloWorld` registers the package.json-declared command id
  - pushes disposable onto `context.subscriptions`
  - executing the command calls `showInformationMessage` with the expected text
  - `activate` wires up the command so `getCommands()` includes it
  - `activate` catches registration errors and surfaces via `showErrorMessage`
  - `deactivate` is a no-op
  - `package.json` contract: every contributed command has a matching `onCommand:` activation event
- Re-ran mutation check with new tests: 5/7 fail when `registerHelloWorld` is broken.
- Dropped `--passWithNoTests` (would mask accidental deletion of all test files).
- `lint` now covers `tests/` too.
- Added `vscode:prepublish` script (`lint && test`) — runs automatically when `vsce package` is invoked.

## Test plan

- [x] `npm test` → 7/7 pass
- [x] `npm run lint` clean across `src/` and `tests/`
- [x] Mutation check: breaking `registerHelloWorld` fails 5 tests; reverting makes them green
- [ ] CI green on push