### PR TITLE
feat: add webview panel example with CSP + bidirectional messaging

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ npm install
 
 # 3. VS Code에서 열고 F5를 눌러 Extension Development Host 실행
 
-# 4. 명령 팔레트 (Ctrl+Shift+P) → "Hello World"
+# 4. 명령 팔레트 (Ctrl+Shift+P) → "Hello World" 또는 "Show Webview Panel"
 ```
 
 ## 포함된 구성
@@ -43,8 +43,10 @@ npm install
 ```
 ├── src/
 │   ├── extension.js              # 메인 진입점 (activate/deactivate)
-│   └── commands/
-│       └── helloWorld.js         # 예제 커맨드
+│   ├── commands/
+│   │   └── helloWorld.js         # 예제 커맨드
+│   └── webview/
+│       └── panel.js              # Webview 패널 예제 (CSP + nonce + 메시징)
 ├── tests/
 │   ├── __mocks__/
 │   │   └── vscode.js            # Jest용 VS Code API 모의 객체
@@ -121,6 +123,38 @@ npm install
 
 자세한 설정 방법은 **[docs/MARKETPLACE_SETUP.md](docs/MARKETPLACE_SETUP.md)**를 참고하세요 (VS Marketplace).
 Open VSX는 **[docs/OPENVSX_SETUP.md](docs/OPENVSX_SETUP.md)**를 참고하세요.
+
+## Webview 예제
+
+명령 팔레트(`Ctrl+Shift+P`)에서 **My Extension: Show Webview Panel** 실행 (command id `my-extension.showWebview`). VS Code 내부에 UI를 만드는 최소 프로덕션 패턴을 보여줍니다.
+
+**내장된 보안 기본값:**
+
+- `default-src 'none'` — 명시적으로 허용한 것만 로드
+- `crypto.randomBytes(16)`로 per-load nonce 생성 — nonce 없는 인라인 스크립트는 차단
+- `localResourceRoots`를 `src/webview/`로 제한 — 임의 파일 읽기 불가
+- `enableScripts: true`는 이 패널에만 적용
+
+**양방향 메시징** — extension host ↔ webview:
+
+```js
+// Webview 쪽 (nonce가 있는 inline <script>)
+const vscode = acquireVsCodeApi();
+document.getElementById('ask').addEventListener('click', () => {
+  vscode.postMessage({ type: 'getWorkspace' });
+});
+
+// Extension 쪽 (src/webview/panel.js)
+panel.webview.onDidReceiveMessage((message) => {
+  if (message.type === 'getWorkspace') {
+    panel.webview.postMessage({ type: 'workspace', data: { /* ... */ } });
+  }
+});
+```
+
+`src/webview/panel.js`의 메시지 핸들러는 `postMessage` 콜백을 인자로 받는 순수 함수라, 실제 Webview API 없이도 유닛 테스트 가능합니다. [`tests/webview.test.js`](tests/webview.test.js) 참고.
+
+공식 문서: [VS Code Webview API 가이드](https://code.visualstudio.com/api/extension-guides/webview).
 
 ## 개발
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install
 
 # 3. Open in VS Code and press F5 to launch Extension Development Host
 
-# 4. Open Command Palette (Ctrl+Shift+P) → "Hello World"
+# 4. Open Command Palette (Ctrl+Shift+P) → "Hello World" or "Show Webview Panel"
 ```
 
 ## What's Included
@@ -43,8 +43,10 @@ npm install
 ```
 ├── src/
 │   ├── extension.js              # Main entry (activate/deactivate)
-│   └── commands/
-│       └── helloWorld.js         # Example command
+│   ├── commands/
+│   │   └── helloWorld.js         # Example command
+│   └── webview/
+│       └── panel.js              # Webview panel example (CSP + nonce + messaging)
 ├── tests/
 │   ├── __mocks__/
 │   │   └── vscode.js            # VS Code API mock for Jest
@@ -121,6 +123,38 @@ npm install
 
 See **[docs/MARKETPLACE_SETUP.md](docs/MARKETPLACE_SETUP.md)** for VS Marketplace setup.
 See **[docs/OPENVSX_SETUP.md](docs/OPENVSX_SETUP.md)** for Open VSX setup.
+
+## Webview example
+
+Open Command Palette (`Ctrl+Shift+P`) and run **My Extension: Show Webview Panel** (command id `my-extension.showWebview`). The panel demonstrates a minimal, production-ready pattern for building UI inside VS Code.
+
+**Security defaults baked in:**
+
+- `default-src 'none'` — nothing loads unless explicitly allowed
+- Per-load nonce generated with `crypto.randomBytes(16)` — inline scripts without it are blocked
+- `localResourceRoots` limited to `src/webview/` — the webview cannot read arbitrary files
+- `enableScripts: true` scoped to this panel only
+
+**Bidirectional messaging** — extension host ↔ webview:
+
+```js
+// Webview side (inline <script nonce="...">)
+const vscode = acquireVsCodeApi();
+document.getElementById('ask').addEventListener('click', () => {
+  vscode.postMessage({ type: 'getWorkspace' });
+});
+
+// Extension side (src/webview/panel.js)
+panel.webview.onDidReceiveMessage((message) => {
+  if (message.type === 'getWorkspace') {
+    panel.webview.postMessage({ type: 'workspace', data: { /* ... */ } });
+  }
+});
+```
+
+The message handler in `src/webview/panel.js` is a pure function that accepts a `postMessage` callback, so it's unit-testable without the real Webview API. See [`tests/webview.test.js`](tests/webview.test.js).
+
+Full docs: [VS Code Webview API guide](https://code.visualstudio.com/api/extension-guides/webview).
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -18,13 +18,19 @@
   ],
   "main": "./src/extension.js",
   "activationEvents": [
-    "onCommand:my-extension.helloWorld"
+    "onCommand:my-extension.helloWorld",
+    "onCommand:my-extension.showWebview"
   ],
   "contributes": {
     "commands": [
       {
         "command": "my-extension.helloWorld",
         "title": "Hello World"
+      },
+      {
+        "command": "my-extension.showWebview",
+        "title": "Show Webview Panel",
+        "category": "My Extension"
       }
     ]
   },

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,5 +1,6 @@
 const vscode = require('vscode');
 const { registerHelloWorld } = require('./commands/helloWorld');
+const { registerShowWebview } = require('./webview/panel');
 
 /**
  * Called when the extension is activated.
@@ -8,6 +9,7 @@ const { registerHelloWorld } = require('./commands/helloWorld');
 function activate(context) {
   try {
     registerHelloWorld(context);
+    registerShowWebview(context);
   } catch (err) {
     vscode.window.showErrorMessage(`Extension activation failed: ${err.message}`);
     console.error('Activation error:', err);

--- a/src/webview/panel.js
+++ b/src/webview/panel.js
@@ -1,0 +1,184 @@
+const vscode = require('vscode');
+const crypto = require('crypto');
+
+/**
+ * Webview panel example — singleton lifecycle with CSP + nonce.
+ *
+ * This module demonstrates the canonical VS Code Webview pattern:
+ *   - enableScripts + locked-down localResourceRoots
+ *   - Per-load nonce that gates inline <script> execution
+ *   - Bidirectional messaging between extension host and webview
+ *
+ * Keep the message handler pure (accepts a postMessage callback) so it can be
+ * unit-tested without spinning up the real Webview API.
+ */
+
+const VIEW_TYPE = 'my-extension.webviewPanel';
+const VIEW_TITLE = 'My Extension';
+
+let currentPanel;
+
+/**
+ * Generate a cryptographically-random nonce suitable for CSP.
+ * @returns {string}
+ */
+function generateNonce() {
+  return crypto.randomBytes(16).toString('base64');
+}
+
+/**
+ * Build the CSP meta tag for the webview. Keep this tight — every relaxation
+ * is an XSS vector. `cspSource` is the opaque origin VS Code mints per load.
+ *
+ * @param {string} cspSource webview.cspSource
+ * @param {string} nonce per-load nonce
+ * @returns {string} CSP policy string (value of the meta tag `content` attr)
+ */
+function buildCsp(cspSource, nonce) {
+  return (
+    `default-src 'none'; ` +
+    `style-src ${cspSource} 'unsafe-inline'; ` +
+    `script-src 'nonce-${nonce}';`
+  );
+}
+
+/**
+ * Render the webview HTML. Exposed for unit tests so CSP/nonce behavior can be
+ * asserted without the real webview.
+ *
+ * @param {{ cspSource: string }} webview — the panel's Webview (or a stub with cspSource)
+ * @param {string} nonce
+ * @returns {string}
+ */
+function renderHtml(webview, nonce) {
+  const csp = buildCsp(webview.cspSource, nonce);
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="${csp}" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${VIEW_TITLE}</title>
+    <style nonce="${nonce}">
+      body { font-family: var(--vscode-font-family); padding: 1rem; color: var(--vscode-foreground); }
+      button {
+        background: var(--vscode-button-background);
+        color: var(--vscode-button-foreground);
+        border: none; padding: 0.5rem 1rem; cursor: pointer;
+      }
+      button:hover { background: var(--vscode-button-hoverBackground); }
+      pre { background: var(--vscode-textCodeBlock-background); padding: 0.75rem; overflow: auto; }
+    </style>
+  </head>
+  <body>
+    <h1>Webview example</h1>
+    <p>Click the button to ask the extension host for workspace info.</p>
+    <button id="ask">Get workspace info</button>
+    <pre id="out">(no response yet)</pre>
+    <script nonce="${nonce}">
+      const vscode = acquireVsCodeApi();
+      const out = document.getElementById('out');
+      document.getElementById('ask').addEventListener('click', () => {
+        vscode.postMessage({ type: 'getWorkspace' });
+      });
+      window.addEventListener('message', (event) => {
+        const msg = event.data;
+        if (msg && msg.type === 'workspace') {
+          out.textContent = JSON.stringify(msg.data, null, 2);
+        }
+      });
+    </script>
+  </body>
+</html>`;
+}
+
+/**
+ * Pure message handler — decoupled from the real webview so tests can pass a
+ * spy `postMessage`. Returns the response it posts (or null) for assertion.
+ *
+ * @param {{ type?: string }} message
+ * @param {(payload: unknown) => void} postMessage
+ * @param {typeof vscode.workspace} [workspaceApi]
+ * @returns {unknown|null}
+ */
+function handleMessage(message, postMessage, workspaceApi = vscode.workspace) {
+  if (!message || typeof message !== 'object') return null;
+  if (message.type === 'getWorkspace') {
+    const folders = (workspaceApi.workspaceFolders || []).map((f) => ({
+      name: f.name,
+      path: f.uri && (f.uri.fsPath || String(f.uri)),
+    }));
+    const response = {
+      type: 'workspace',
+      data: { name: workspaceApi.name || null, folders },
+    };
+    postMessage(response);
+    return response;
+  }
+  return null;
+}
+
+/**
+ * Create the panel or reveal the existing one.
+ * @param {vscode.ExtensionContext} context
+ */
+function createOrShow(context) {
+  const column = vscode.window.activeTextEditor
+    ? vscode.window.activeTextEditor.viewColumn
+    : undefined;
+
+  if (currentPanel) {
+    currentPanel.reveal(column);
+    return currentPanel;
+  }
+
+  const panel = vscode.window.createWebviewPanel(VIEW_TYPE, VIEW_TITLE, column || 1, {
+    enableScripts: true,
+    localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'src', 'webview')],
+    retainContextWhenHidden: false,
+  });
+
+  const nonce = generateNonce();
+  panel.webview.html = renderHtml(panel.webview, nonce);
+
+  panel.webview.onDidReceiveMessage(
+    (message) => handleMessage(message, (payload) => panel.webview.postMessage(payload)),
+    undefined,
+    context.subscriptions
+  );
+
+  panel.onDidDispose(
+    () => {
+      if (currentPanel === panel) currentPanel = undefined;
+    },
+    null,
+    context.subscriptions
+  );
+
+  currentPanel = panel;
+  return panel;
+}
+
+/**
+ * Register the command that opens the webview.
+ * @param {vscode.ExtensionContext} context
+ */
+function registerShowWebview(context) {
+  const disposable = vscode.commands.registerCommand('my-extension.showWebview', () => {
+    createOrShow(context);
+  });
+  context.subscriptions.push(disposable);
+}
+
+module.exports = {
+  registerShowWebview,
+  createOrShow,
+  renderHtml,
+  buildCsp,
+  generateNonce,
+  handleMessage,
+  // Exposed for tests that need to reset singleton state.
+  __reset: () => {
+    currentPanel = undefined;
+  },
+};

--- a/tests/__mocks__/vscode.js
+++ b/tests/__mocks__/vscode.js
@@ -21,21 +21,66 @@ const commands = {
   getCommands: jest.fn(() => Promise.resolve([...registeredCommands.keys()])),
 };
 
+// Tracks the last webview panel created, so tests can introspect it.
+let lastPanel = null;
+
+function createWebviewPanelImpl(viewType, title, _column, _options) {
+  const messageListeners = [];
+  const disposeListeners = [];
+  const webview = {
+    cspSource: 'vscode-webview://mock',
+    html: '',
+    postMessage: jest.fn(() => Promise.resolve(true)),
+    onDidReceiveMessage: jest.fn((listener) => {
+      messageListeners.push(listener);
+      return { dispose: jest.fn() };
+    }),
+  };
+  const panel = {
+    viewType,
+    title,
+    webview,
+    visible: true,
+    reveal: jest.fn(),
+    dispose: jest.fn(() => {
+      disposeListeners.forEach((l) => l());
+    }),
+    onDidDispose: jest.fn((listener) => {
+      disposeListeners.push(listener);
+      return { dispose: jest.fn() };
+    }),
+    // Test helpers — not part of the real Webview API.
+    __fireMessage: (msg) => messageListeners.forEach((l) => l(msg)),
+  };
+  lastPanel = panel;
+  return panel;
+}
+
 const window = {
   showInformationMessage: jest.fn(),
   showErrorMessage: jest.fn(),
   showWarningMessage: jest.fn(),
+  activeTextEditor: undefined,
+  createWebviewPanel: jest.fn(createWebviewPanelImpl),
 };
 
 const workspace = {
   getConfiguration: jest.fn(() => ({ get: jest.fn() })),
+  name: undefined,
+  workspaceFolders: undefined,
+};
+
+const Uri = {
+  file: (f) => f,
+  parse: (s) => s,
+  joinPath: (base, ...parts) => ({ fsPath: [base, ...parts].join('/'), toString: () => [base, ...parts].join('/') }),
 };
 
 module.exports = {
   commands,
   window,
   workspace,
-  Uri: { file: (f) => f, parse: (s) => s },
+  Uri,
   ExtensionContext: {},
   // Exposed for test setup/teardown only — not part of the real vscode API.
   __reset: () => {
@@ -46,6 +91,12 @@ module.exports = {
     window.showInformationMessage.mockClear();
     window.showErrorMessage.mockClear();
     window.showWarningMessage.mockClear();
+    window.createWebviewPanel.mockClear();
+    window.activeTextEditor = undefined;
     workspace.getConfiguration.mockClear();
+    workspace.name = undefined;
+    workspace.workspaceFolders = undefined;
+    lastPanel = null;
   },
+  __getLastPanel: () => lastPanel,
 };

--- a/tests/extension.test.js
+++ b/tests/extension.test.js
@@ -18,7 +18,9 @@ beforeEach(() => {
 describe('registerHelloWorld', () => {
   test('registers the command id declared in package.json', () => {
     const context = createContext();
-    const declared = pkg.contributes.commands[0].command;
+    const declared = pkg.contributes.commands.find(
+      (c) => c.command === 'my-extension.helloWorld'
+    ).command;
 
     registerHelloWorld(context);
 
@@ -54,12 +56,15 @@ describe('registerHelloWorld', () => {
 describe('activate', () => {
   test('registers the helloWorld command on activation', async () => {
     const context = createContext();
+    context.extensionUri = 'file:///fake/ext';
 
     activate(context);
 
     const registered = await vscode.commands.getCommands();
     expect(registered).toContain('my-extension.helloWorld');
-    expect(context.subscriptions).toHaveLength(1);
+    expect(registered).toContain('my-extension.showWebview');
+    // One disposable per contributed command.
+    expect(context.subscriptions).toHaveLength(2);
   });
 
   test('surfaces errors via showErrorMessage instead of throwing', () => {

--- a/tests/webview.test.js
+++ b/tests/webview.test.js
@@ -1,0 +1,182 @@
+const vscode = require('vscode');
+const {
+  renderHtml,
+  buildCsp,
+  generateNonce,
+  handleMessage,
+  registerShowWebview,
+  createOrShow,
+  __reset: resetPanel,
+} = require('../src/webview/panel');
+const pkg = require('../package.json');
+
+function createContext() {
+  return { subscriptions: [], extensionUri: 'file:///fake/ext' };
+}
+
+beforeEach(() => {
+  vscode.__reset();
+  resetPanel();
+});
+
+describe('generateNonce', () => {
+  test('produces distinct values across calls', () => {
+    const a = generateNonce();
+    const b = generateNonce();
+    expect(a).not.toBe(b);
+    // base64 of 16 bytes -> 24 chars including padding
+    expect(a).toMatch(/^[A-Za-z0-9+/=]+$/);
+    expect(a.length).toBeGreaterThanOrEqual(22);
+  });
+});
+
+describe('buildCsp', () => {
+  test('interpolates cspSource and nonce and locks default-src to none', () => {
+    const csp = buildCsp('vscode-webview://abc', 'N0NCE');
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain('style-src vscode-webview://abc');
+    expect(csp).toContain("script-src 'nonce-N0NCE'");
+    // Sanity: no wildcard that would defeat CSP.
+    expect(csp).not.toContain("script-src *");
+    expect(csp).not.toContain("'unsafe-eval'");
+  });
+});
+
+describe('renderHtml', () => {
+  test('embeds CSP meta, cspSource, and the provided nonce', () => {
+    const webview = { cspSource: 'vscode-webview://abc' };
+    const html = renderHtml(webview, 'NONCE-A');
+    expect(html).toContain('<meta http-equiv="Content-Security-Policy"');
+    expect(html).toContain("default-src 'none'");
+    expect(html).toContain('vscode-webview://abc');
+    expect(html).toContain('nonce-NONCE-A');
+    // Every script tag must carry the nonce — inline scripts without it are blocked.
+    const scriptOpenTags = html.match(/<script\b[^>]*>/g) || [];
+    expect(scriptOpenTags.length).toBeGreaterThan(0);
+    for (const tag of scriptOpenTags) {
+      expect(tag).toContain('nonce="NONCE-A"');
+    }
+  });
+
+  test('uses a fresh nonce each call when driven by generateNonce', () => {
+    const webview = { cspSource: 'vscode-webview://x' };
+    const a = renderHtml(webview, generateNonce());
+    const b = renderHtml(webview, generateNonce());
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('handleMessage', () => {
+  test('getWorkspace returns a workspace response with name + folders', () => {
+    const post = jest.fn();
+    const response = handleMessage(
+      { type: 'getWorkspace' },
+      post,
+      {
+        name: 'demo.code-workspace',
+        workspaceFolders: [{ name: 'repo', uri: { fsPath: '/tmp/repo' } }],
+      }
+    );
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(response).toEqual({
+      type: 'workspace',
+      data: {
+        name: 'demo.code-workspace',
+        folders: [{ name: 'repo', path: '/tmp/repo' }],
+      },
+    });
+    expect(post).toHaveBeenCalledWith(response);
+  });
+
+  test('handles missing workspaceFolders gracefully', () => {
+    const post = jest.fn();
+    const response = handleMessage({ type: 'getWorkspace' }, post, {});
+    expect(response).toEqual({ type: 'workspace', data: { name: null, folders: [] } });
+  });
+
+  test('ignores unknown message types without posting', () => {
+    const post = jest.fn();
+    const response = handleMessage({ type: 'unknown' }, post, {});
+    expect(response).toBeNull();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  test('ignores malformed messages', () => {
+    const post = jest.fn();
+    expect(handleMessage(null, post, {})).toBeNull();
+    expect(handleMessage('string', post, {})).toBeNull();
+    expect(post).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerShowWebview + createOrShow', () => {
+  test('registers the command declared in package.json', () => {
+    const context = createContext();
+    const declared = pkg.contributes.commands.find(
+      (c) => c.command === 'my-extension.showWebview'
+    );
+    expect(declared).toBeDefined();
+
+    registerShowWebview(context);
+
+    expect(vscode.commands.registerCommand).toHaveBeenCalledWith(
+      'my-extension.showWebview',
+      expect.any(Function)
+    );
+    expect(context.subscriptions).toHaveLength(1);
+  });
+
+  test('executing the command creates a webview panel with locked-down options', async () => {
+    const context = createContext();
+    registerShowWebview(context);
+
+    await vscode.commands.executeCommand('my-extension.showWebview');
+
+    expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1);
+    const [, , , options] = vscode.window.createWebviewPanel.mock.calls[0];
+    expect(options.enableScripts).toBe(true);
+    expect(Array.isArray(options.localResourceRoots)).toBe(true);
+    expect(options.localResourceRoots).toHaveLength(1);
+  });
+
+  test('reuses the existing panel instead of creating a second one', () => {
+    const context = createContext();
+    const first = createOrShow(context);
+    const second = createOrShow(context);
+    expect(second).toBe(first);
+    expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1);
+    expect(first.reveal).toHaveBeenCalled();
+  });
+
+  test('disposing the panel clears the singleton so the next call recreates', () => {
+    const context = createContext();
+    const first = createOrShow(context);
+    first.dispose(); // fires onDidDispose listeners
+    const second = createOrShow(context);
+    expect(second).not.toBe(first);
+    expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(2);
+  });
+
+  test('webview messages flow through to postMessage', () => {
+    const context = createContext();
+    vscode.workspace.name = 'demo';
+    vscode.workspace.workspaceFolders = [{ name: 'r', uri: { fsPath: '/r' } }];
+    const panel = createOrShow(context);
+
+    panel.__fireMessage({ type: 'getWorkspace' });
+
+    expect(panel.webview.postMessage).toHaveBeenCalledWith({
+      type: 'workspace',
+      data: { name: 'demo', folders: [{ name: 'r', path: '/r' }] },
+    });
+  });
+});
+
+describe('package.json contract (webview command)', () => {
+  test('showWebview has an activationEvent', () => {
+    expect(pkg.contributes.commands.map((c) => c.command)).toContain(
+      'my-extension.showWebview'
+    );
+    expect(pkg.activationEvents).toContain('onCommand:my-extension.showWebview');
+  });
+});

--- a/tests/webview.test.js
+++ b/tests/webview.test.js
@@ -51,7 +51,9 @@ describe('renderHtml', () => {
     expect(html).toContain('vscode-webview://abc');
     expect(html).toContain('nonce-NONCE-A');
     // Every script tag must carry the nonce — inline scripts without it are blocked.
-    const scriptOpenTags = html.match(/<script\b[^>]*>/g) || [];
+    // Case-insensitive regex: CodeQL js/bad-tag-filter flags case-sensitive HTML regexes
+    // because HTML tag names are case-insensitive in browsers.
+    const scriptOpenTags = html.match(/<script\b[^>]*>/gi) || [];
     expect(scriptOpenTags.length).toBeGreaterThan(0);
     for (const tag of scriptOpenTags) {
       expect(tag).toContain('nonce="NONCE-A"');


### PR DESCRIPTION
## Summary

Adds a second example command, `my-extension.showWebview`, that opens a singleton `WebviewPanel` demonstrating the canonical VS Code UI-inside-VS-Code pattern.

- **Secure defaults**: `default-src 'none'; style-src \${cspSource} 'unsafe-inline'; script-src 'nonce-<nonce>';` — per-load nonce via `crypto.randomBytes(16)`, `localResourceRoots` scoped to `src/webview/`, `enableScripts` limited to the panel.
- **Bidirectional messaging**: webview button posts `{ type: 'getWorkspace' }`; extension host replies with `{ type: 'workspace', data: { name, folders } }`.
- **Testable**: message handler is a pure function that accepts a `postMessage` callback, so it unit-tests without spinning up the real Webview API.
- **Lifecycle**: singleton — reveal if already open, dispose clears the reference, next call recreates.

## Changes

- `src/webview/panel.js` (new) — `renderHtml`, `buildCsp`, `generateNonce`, `handleMessage`, `createOrShow`, `registerShowWebview`
- `src/extension.js` — registers the new command
- `package.json` — `contributes.commands` + `activationEvents` entries
- `tests/webview.test.js` (new) — 14 tests covering CSP, nonce uniqueness, message shape, panel reuse, dispose/recreate
- `tests/__mocks__/vscode.js` — adds `createWebviewPanel`, `Uri.joinPath`, workspace fields
- `tests/extension.test.js` — updated `activate` test for the additional command
- `README.md` + `README.ko.md` — new Webview example section with pattern snippet, security notes, link to official [Webview API docs](https://code.visualstudio.com/api/extension-guides/webview)

Mutation check: flipping `default-src 'none'` -> `*` fails the CSP test.

Bundle delta: **6.3 KB -> 9.36 KB (+3.06 KB)**, 7 -> 8 files. Runtime dependencies: still 0.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — 21 passed (7 existing + 14 new)
- [x] `npx vsce package --no-dependencies` builds successfully
- [x] Mutation check: breaking `buildCsp` causes the CSP-contents test to fail
- [ ] CI green