### PR TITLE
docs: add create-starter install path as first Quick Start option

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -25,18 +25,23 @@
 
 ## 빠른 시작
 
+**[create-starter](https://github.com/starter-series/create-starter) 사용** (권장):
+
 ```bash
-# 1. GitHub에서 "Use this template" 클릭 (또는 clone)
-git clone https://github.com/starter-series/vscode-extension-starter.git my-extension
-cd my-extension
-
-# 2. 의존성 설치
-npm install
-
-# 3. VS Code에서 열고 F5를 눌러 Extension Development Host 실행
-
-# 4. 명령 팔레트 (Ctrl+Shift+P) → "Hello World" 또는 "Show Webview Panel"
+npx @starter-series/create my-vscode-extension --template vscode-extension
+cd my-vscode-extension && npm install
+# VS Code에서 열고 F5를 눌러 Extension Development Host 실행
 ```
+
+**또는 직접 clone:**
+
+```bash
+git clone https://github.com/starter-series/vscode-extension-starter my-vscode-extension
+cd my-vscode-extension && npm install
+# VS Code에서 열고 F5
+```
+
+그 다음 명령 팔레트(`Ctrl+Shift+P`)에서 **Hello World** 또는 **Show Webview Panel** 실행.
 
 ## 포함된 구성
 

--- a/README.md
+++ b/README.md
@@ -25,18 +25,23 @@ Build your extension. Push to publish.
 
 ## Quick Start
 
+**Via [create-starter](https://github.com/starter-series/create-starter)** (recommended):
+
 ```bash
-# 1. Click "Use this template" on GitHub (or clone)
-git clone https://github.com/starter-series/vscode-extension-starter.git my-extension
-cd my-extension
-
-# 2. Install dependencies
-npm install
-
-# 3. Open in VS Code and press F5 to launch Extension Development Host
-
-# 4. Open Command Palette (Ctrl+Shift+P) → "Hello World" or "Show Webview Panel"
+npx @starter-series/create my-vscode-extension --template vscode-extension
+cd my-vscode-extension && npm install
+# Open in VS Code and press F5 to launch Extension Development Host
 ```
+
+**Or clone directly:**
+
+```bash
+git clone https://github.com/starter-series/vscode-extension-starter my-vscode-extension
+cd my-vscode-extension && npm install
+# Open in VS Code and press F5
+```
+
+Then open Command Palette (`Ctrl+Shift+P`) → **Hello World** or **Show Webview Panel**.
 
 ## What's Included
 


### PR DESCRIPTION
## Summary

- Add `npx @starter-series/create my-vscode-extension --template vscode-extension` as the recommended install path at the top of Quick Start
- Keep `git clone` path as an alternative below
- Mirror in `README.ko.md` with Korean headings and translated comments

## Test plan

- [x] README.md renders with both install paths
- [x] README.ko.md mirrors structure with Korean comments
- [x] CI passes