### PR TITLE
chore: bump Node to >=22 (Node 20 EOL 2026-04-30)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Check for large files

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/starter-series/vscode-extension-starter"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "vscode": "^1.85.0"
   },
   "categories": [


### PR DESCRIPTION
Node 20 reached end-of-life on 2026-04-30. Bumps `engines.node` and CI `node-version` to 22 (active LTS through 2027-04). GitHub Actions runner default flips to Node 24 on 2026-06-02 (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## Test plan
- [ ] CI green on Node 22