### PR TITLE
chore(test): add jest coverageThreshold gate (baseline-aware)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "lint": "eslint src/ tests/",
-    "test": "jest --verbose",
+    "test": "jest --verbose --coverage",
     "vscode:prepublish": "npm run lint && npm test",
     "package": "vsce package --no-dependencies",
     "version:patch": "node scripts/bump-version.js patch",
@@ -46,6 +46,14 @@
   "jest": {
     "moduleNameMapper": {
       "^vscode$": "<rootDir>/tests/__mocks__/vscode.js"
+    },
+    "coverageThreshold": {
+      "global": {
+        "statements": 95,
+        "branches": 80,
+        "functions": 95,
+        "lines": 95
+      }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Locks in the current coverage floor so regressions fail CI. Threshold is set **just below** today's measured floor — fresh contributors see green numbers and a regression turns the gate red.

## Test plan
- [x] Local `npm test -- --coverage` passes the configured threshold
- [ ] CI green