### PR TITLE
fix(deps): scope npm overrides + add brace-expansion regression test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,6 +1337,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@jest/reporters/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@jest/reporters/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -3718,6 +3735,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5731,6 +5755,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/jest-config/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/jest-config/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -6194,6 +6235,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/jest-runtime/node_modules/emoji-regex": {
@@ -6924,6 +6982,24 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/minimist": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
   },
   "overrides": {
     "tmp": "^0.2.7",
-    "brace-expansion": "^5.0.5",
+    "brace-expansion@^5": "^5.0.6",
+    "brace-expansion@^2": "^2.0.4",
     "fast-uri": "^3.1.2",
     "follow-redirects": "^1.15.12",
     "qs": "^6.15.2",

--- a/tests/overrides-regression.test.js
+++ b/tests/overrides-regression.test.js
@@ -1,0 +1,65 @@
+/**
+ * Regression guard for the `overrides` block in package.json.
+ *
+ * Background — second-pass code review (2026-05-27) found that a blanket
+ *   "brace-expansion": "^5.0.5"
+ * override forced minimatch@3.1.5 (a transitive dep of @vscode/vsce and of
+ * jest's test-exclude chain via babel-plugin-istanbul → glob@7) to load
+ * brace-expansion@5. brace-expansion@5 ships CJS named-only exports
+ * ({ expand, EXPANSION_MAX }), but minimatch@3's source does
+ *   var expand = require('brace-expansion');  // expects a callable default
+ *   ...
+ *   return expand(pattern);
+ * so any glob containing braces — e.g. `{a,b}`, `.vscodeignore` patterns
+ * like `**\/{spec,test}/*.test.js`, or jest testMatch with brace alternates
+ * — throws `TypeError: expand is not a function` deep inside vsce package /
+ * jest coverage walking.
+ *
+ * The current scoped override (`brace-expansion@^5` → ^5.0.6,
+ * `brace-expansion@^2` → ^2.0.4) leaves minimatch@3 on its native v1 chain.
+ *
+ * These tests pin that contract. If anyone collapses the override back to a
+ * blanket `"brace-expansion": "^5"`, the second test crashes the suite with
+ * the same TypeError the original audit caught.
+ */
+const path = require('path');
+
+describe('overrides regression — minimatch ↔ brace-expansion contract', () => {
+  // We deliberately do NOT assert what `require("brace-expansion")` returns at
+  // the project root — npm's hoist order is not a contract and shifts between
+  // installs. What matters is that minimatch@3 (the consumer that would crash
+  // under a blanket override) sees a callable brace-expansion in *its own*
+  // resolution path, which the test below proves end-to-end.
+
+  test('minimatch@3 (vsce + test-exclude dep) handles brace patterns without throwing', () => {
+    // Hard-pin to the v3 copy that @vscode/vsce loads. If npm later hoists
+    // a different minimatch into the top-level slot, update this path.
+    const mmPath = path.join(__dirname, '..', 'node_modules', 'minimatch', 'minimatch.js');
+    const minimatch = require(mmPath);
+
+    // Sanity: no-brace pattern.
+    expect(minimatch('foo.test.js', '**/*.test.js')).toBe(true);
+
+    // The crash case — `{a,b}` walks through brace-expansion as a function call.
+    expect(() => minimatch('a', '{a,b}')).not.toThrow();
+    expect(minimatch('a', '{a,b}')).toBe(true);
+    expect(minimatch('b', '{a,b}')).toBe(true);
+    expect(minimatch('c', '{a,b}')).toBe(false);
+
+    // Realistic .vscodeignore-style pattern with braces.
+    expect(() => minimatch('src/foo.spec.js', '**/{spec,test}/*.js')).not.toThrow();
+  });
+
+  test('package.json overrides keep brace-expansion scoped by major', () => {
+    // Belt-and-suspenders: if someone removes the version selectors, this
+    // test surfaces the misconfiguration before it manifests as a TypeError
+    // deep inside vsce/jest internals.
+    const pkg = require('../package.json');
+    expect(pkg.overrides).toBeDefined();
+    const beKey = Object.keys(pkg.overrides).find((k) => k.startsWith('brace-expansion'));
+    expect(beKey).toBeDefined();
+    // A blanket "brace-expansion" key would force the v1 chain to v5 and
+    // re-introduce the contract break.
+    expect(beKey).toMatch(/^brace-expansion@/);
+  });
+});


### PR DESCRIPTION
## Summary

Two commits:

1. **`9b6ca8c`** — Add npm `overrides` for 6 transitive deps to clear the `tmp <0.2.6` (GHSA-ph9p-34f9-6g65) advisory and other high/moderate findings.

2. **`1b53041`** — **Fix** the blanket `brace-expansion: ^5.0.5` override caught in second-pass review. The blanket form forced `minimatch@3.1.5` (direct dep of `@vscode/vsce`, transitive of jest's test-exclude) onto brace-expansion@5, whose CJS exports break the `require('brace-expansion')(pattern)` callable contract minimatch@3 was written against.

   Direct repro pre-fix:
   ```
   $ node -e "require('./node_modules/minimatch/minimatch.js')('a','{a,b}')"
   TypeError: expand is not a function
   ```

   Scoped fix:
   ```json
   "brace-expansion@^5": "^5.0.6",
   "brace-expansion@^2": "^2.0.4"
   ```

   minimatch@3 now resolves brace-expansion@1.1.15 (native dep); v5/v9/v10 paths still get the security-patched v5.0.6.

## Why this didn't crash CI before merge

The current `.vscodeignore`, jest `testMatch`, and eslint configs in this template don't use brace patterns, so the TypeError stayed latent. The starter is designed to be forked and customized — the moment a user adds `{a,b}` to any glob, vsce / jest crashes deep inside minimatch.

## Regression test

`tests/overrides-regression.test.js` asserts:
1. `minimatch('a', '{a,b}')` and `.vscodeignore`-style brace globs work end-to-end.
2. The package.json override key uses a version selector (`brace-expansion@^N`), not a blanket key.

Negative-test confirmed: re-applying the blanket override and running this suite fails 2/2 tests.

## Test plan

- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] `npm test` → 23/23 (21 existing + 2 regression)
- [x] `npm run lint` → clean
- [x] `npx vsce package --no-dependencies` → 10 KB .vsix builds
- [x] `node -e "require('./node_modules/minimatch/minimatch.js')('a','{a,b}')"` → `true`
- [x] Negative-test: blanket override applied → regression suite fails 2/2

## Follow-up (out of scope for this PR)

Second-pass review surfaced 12 additional findings on the override block. Tracked in the session transcript:

- `uuid: ^11.1.1` caret caps the project on legacy major 11 — future CVE on uuid 12+ excluded
- `tmp: ^0.2.7` caret excludes future 0.3.x security fixes (same logic for `qs ^6.15.2`, `follow-redirects ^1.15.12`)
- Dependabot config does not watch the `overrides` block — these pins are now outside any automation
- Blanket overrides propagate to forks; `README.md:20` invites forking
- Commit message of `9b6ca8c` claims to mirror create-starter PR #47, but #47 adds direct dependencies, not overrides — the cited precedent does not exist
- Pre-existing `.nvmrc:1=20` vs `engines.node:'>=22'` + `engine-strict=true` mismatch

These don't block this PR but should be addressed in subsequent sweeps.