### PR TITLE
[codex] Harden VS Code extension starter

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,8 +2,10 @@
 .github/**
 node_modules/**
 tests/**
+coverage/**
 docs/**
 scripts/**
+*.vsix
 eslint.config.*
 .eslintrc*
 package-lock.json

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,7 +47,7 @@ cd my-vscode-extension && npm install
 
 ## 현재 구현됨 (Currently implemented)
 
-아래 항목은 모두 디스크상의 코드로 뒷받침되며, Jest로 검증됩니다 (21개 테스트 통과, statement 커버리지 100%).
+아래 항목은 모두 디스크상의 코드로 뒷받침되며, Jest로 검증됩니다 (40개 테스트 통과, statement 커버리지 100%).
 
 - **Vanilla JS 확장 스캐폴드** — `src/extension.js` (activate/deactivate), `src/commands/helloWorld.js` (커맨드 예제), `src/webview/panel.js` (CSP + nonce + 양방향 메시징).
 - **CI 파이프라인** (`.github/workflows/ci.yml`) — `npm audit`, ESLint v9 flat config, Jest 커버리지 게이트, `vsce package` 빌드 검증.
@@ -64,7 +64,9 @@ cd my-vscode-extension && npm install
 │   └── webview/panel.js          # Webview 패널 (CSP + nonce + 메시징)
 ├── tests/
 │   ├── __mocks__/vscode.js       # Jest용 VS Code API 모의 객체
+│   ├── bump-version.test.js
 │   ├── extension.test.js
+│   ├── overrides-regression.test.js
 │   └── webview.test.js
 ├── .github/workflows/
 │   ├── ci.yml                    # 린트, 테스트, 패키지 검증
@@ -113,7 +115,7 @@ cd my-vscode-extension && npm install
 | 보안 감사 | `npm audit`로 의존성 취약점 확인 |
 | 린트 | ESLint v9 flat config |
 | 테스트 | Jest 커버리지 게이트 |
-| 패키지 검증 | `.vsix` 빌드 성공 여부 확인 |
+| 빌드 / 패키지 검증 | `npm run build` / `vsce package`로 `.vsix` 성공 여부 확인 |
 
 ### 보안 & 유지보수
 
@@ -194,6 +196,7 @@ npm run version:minor   # 0.1.0 → 0.2.0
 npm run version:major   # 0.1.0 → 1.0.0
 
 # .vsix 패키지 빌드
+npm run build
 npm run package
 
 # 린트 & 테스트

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then open Command Palette (`Ctrl+Shift+P`) → **Hello World** or **Show Webview
 
 ## Currently implemented
 
-Everything below is backed by code on disk and exercised by Jest (21 tests passing, 100% statement coverage).
+Everything below is backed by code on disk and exercised by Jest (40 tests passing, 100% statement coverage).
 
 - **Vanilla JS extension scaffold** — `src/extension.js` (activate/deactivate), `src/commands/helloWorld.js` (command example), `src/webview/panel.js` (CSP + nonce + bidirectional messaging).
 - **CI pipeline** (`.github/workflows/ci.yml`) — `npm audit`, ESLint v9 flat config, Jest with coverage gate, `vsce package` build verification.
@@ -64,7 +64,9 @@ Everything below is backed by code on disk and exercised by Jest (21 tests passi
 │   └── webview/panel.js          # Webview panel (CSP + nonce + messaging)
 ├── tests/
 │   ├── __mocks__/vscode.js       # VS Code API mock for Jest
+│   ├── bump-version.test.js
 │   ├── extension.test.js
+│   ├── overrides-regression.test.js
 │   └── webview.test.js
 ├── .github/workflows/
 │   ├── ci.yml                    # Lint, test, package verification
@@ -113,7 +115,7 @@ Everything below is backed by code on disk and exercised by Jest (21 tests passi
 | Security audit | `npm audit` for dependency vulnerabilities |
 | Lint | ESLint v9 flat config |
 | Test | Jest with coverage gate |
-| Package verification | Builds `.vsix` and verifies it succeeds |
+| Build / package verification | Runs `npm run build` / `vsce package` and verifies `.vsix` succeeds |
 
 ### Security & Maintenance
 
@@ -195,6 +197,7 @@ npm run version:minor   # 0.1.0 → 0.2.0
 npm run version:major   # 0.1.0 → 1.0.0
 
 # Build .vsix package
+npm run build
 npm run package
 
 # Lint & test

--- a/package-lock.json
+++ b/package-lock.json
@@ -8969,9 +8969,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "lint": "eslint src/ tests/",
     "test": "jest --verbose --coverage",
+    "build": "npm run package",
     "vscode:prepublish": "npm run lint && npm test",
     "package": "vsce package --no-dependencies",
     "version:patch": "node scripts/bump-version.js patch",


### PR DESCRIPTION
## Summary
- add a real npm build script that runs the VSIX package smoke
- refresh README/README.ko verification claims to match the current test surface
- exclude generated coverage and VSIX artifacts from extension packages
- refresh the lockfile to remove the high-severity undici audit finding

## Validation
- npm ci --ignore-scripts
- npm test
- npm run lint
- npm run build
- npm run package
- npm audit --audit-level=high
- npm pack --dry-run --json
- npx license-checker --failOn "GPL-2.0;GPL-3.0;AGPL-3.0"