### PR TITLE
docs: align first-user template path

### DIFF
--- a/.cursor/rules/repo-context.mdc
+++ b/.cursor/rules/repo-context.mdc
@@ -1,0 +1,10 @@
+---
+description: Shared repo context
+alwaysApply: true
+---
+
+Read `AGENTS.md` first. Treat it as the source of truth for this repo's
+commands, invariants, public naming, release constraints, and first-user path.
+
+This file is a thin client adapter for Cursor. Do not add independent strategy,
+roadmap, package-name, release, or baseline-scope rules here.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+# Agent context
+
+Read `AGENTS.md` first. Treat it as the source of truth for this repo's
+commands, invariants, public naming, release constraints, and first-user path.
+
+This file is a thin client adapter for GitHub Copilot and VS Code. Do not add
+independent strategy, roadmap, package-name, release, or baseline-scope rules
+here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Agent context
+
+Read `AGENTS.md` first. Treat it as the source of truth for this repo's
+commands, invariants, public naming, release constraints, and first-user path.
+
+This file is a thin client adapter. Do not add independent strategy, roadmap,
+package-name, release, or baseline-scope rules here.

--- a/README.ko.md
+++ b/README.ko.md
@@ -28,7 +28,7 @@
 **[create-starter](https://github.com/starter-series/create-starter) 사용** (권장):
 
 ```bash
-npx @starter-series/create my-vscode-extension --template vscode-extension
+gh repo create my-vscode-extension --template starter-series/vscode-extension-starter --clone
 cd my-vscode-extension && npm install
 npm run build
 # VS Code에서 열고 F5를 눌러 Extension Development Host 실행

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Build your extension. Push to publish.
 **Via [create-starter](https://github.com/starter-series/create-starter)** (recommended):
 
 ```bash
-npx @starter-series/create my-vscode-extension --template vscode-extension
+gh repo create my-vscode-extension --template starter-series/vscode-extension-starter --clone
 cd my-vscode-extension && npm install
 npm run build
 # Open in VS Code and press F5 to launch Extension Development Host

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@vscode/vsce": "^3.9.2",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "globals": "^17.7.0",
         "jest": "^30.4.2",
         "ovsx": "^0.10.11"
@@ -4257,9 +4257,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@vscode/vsce": "^3.9.2",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "globals": "^17.7.0",
     "jest": "^30.4.2",
     "ovsx": "^0.10.11"


### PR DESCRIPTION
## Summary
- Aligns the repo with the current starter-series first-user path and unscoped package naming contract.
- Keeps agent-facing adapters thin so Codex, Claude, Cursor, VS Code/Copilot, and similar shell-driven tools read the same repo-local source of truth.
- Tightens repo-local verification where the touched surface affects install, package, CI, or release behavior.

## Verification
- Repo-local lint/test/build/package gates were run before commit where applicable.
- Staged whitespace checks passed before commit.
- CI on this PR is the merge gate.